### PR TITLE
[feat] #5 chatting Entity 생성 및 jpa AuditConfig 설정을 통한 createdAt 자동 생성 (1차 구현 추후 리뷰 후 리팩토링 예정)

### DIFF
--- a/src/main/java/sopt35/linkareer/domain/chatting/infra/Chatting.java
+++ b/src/main/java/sopt35/linkareer/domain/chatting/infra/Chatting.java
@@ -1,0 +1,43 @@
+package sopt35.linkareer.domain.chatting.infra;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class Chatting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String message;
+
+    private boolean isReplied;
+
+    private String replyMessage;
+
+    private String replySender;
+
+    @Column(columnDefinition = "0")
+    private int likes;
+
+    private boolean pressedLike;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/sopt35/linkareer/global/config/JpaAuditingConfig.java
+++ b/src/main/java/sopt35/linkareer/global/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package sopt35.linkareer.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- ex) #이슈번호, #이슈번호

#5 

### 🎋 작업중인 브랜치
- 작업 중인 브랜치를 알려주세요.

feat#5

### 💡 작업내용
- 작업 배경을 알려주세요.

- chatting Entity 생성
- jpa AuditConfiguration 설정을 통한 createdDate 자동 생성 진행

### 🔑 주요 변경사항
- 주요 변경사항 목록을 알려주세요.

### 🏞 스크린샷
스크린샷을 첨부해주세요.

![image](https://github.com/user-attachments/assets/46c8a910-b6c6-446a-8c71-9d2791a5b7fa)


closes #5
