### PR TITLE
[feat] #10 추천 공고, 실시간 인기 공고 API 구현

### DIFF
--- a/src/main/java/sopt35/linkareer/api/controller/OfficialController.java
+++ b/src/main/java/sopt35/linkareer/api/controller/OfficialController.java
@@ -3,12 +3,10 @@ package sopt35.linkareer.api.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import sopt35.linkareer.api.dto.response.ErrorCode;
 import sopt35.linkareer.api.dto.response.OfficialListResponse;
 import sopt35.linkareer.domain.official.application.dto.response.OfficialDto;
 import sopt35.linkareer.domain.official.application.service.OfficialService;
-import sopt35.linkareer.domain.official.infra.Category;
-import sopt35.linkareer.global.exception.LinkareerException;
+import sopt35.linkareer.domain.official.validator.CategoryValidator;
 
 import java.util.List;
 
@@ -17,9 +15,11 @@ import java.util.List;
 public class OfficialController {
 
     private final OfficialService officialService;
+    private final CategoryValidator categoryValidator;
 
-    public OfficialController(OfficialService officialService) {
+    public OfficialController(OfficialService officialService, CategoryValidator categoryValidator) {
         this.officialService = officialService;
+        this.categoryValidator = categoryValidator;
     }
 
     // 카테고리에 맞는 공고 리스트를 조회하는 API
@@ -30,25 +30,10 @@ public class OfficialController {
     ) {
         List<OfficialDto> officialList = officialService.getOfficialListByCategory(
                 memberId,
-                validateCreateCategory(category)
+                categoryValidator.validate(category)
         );
         return ResponseEntity.ok(OfficialListResponse.from(officialList));
     }
 
-    // 카테고리 유효성 검사 메서드
-    private Category validateCreateCategory(String category) {
-        if (category == null || category.isEmpty()) {
-            throw new LinkareerException(ErrorCode.INVALID_INPUT_CATEGORY_VALUE);
-        }
-        return validateCategory(category);
-    }
 
-    // 카테고리 값을 검증하고 변환하는 메서드
-    private Category validateCategory(String category) {
-        try {
-            return Category.valueOf(category.toUpperCase());
-        } catch (IllegalArgumentException e) {
-            throw new LinkareerException(ErrorCode.CATEGORY_NOT_FOUND);
-        }
-    }
 }

--- a/src/main/java/sopt35/linkareer/api/controller/OfficialController.java
+++ b/src/main/java/sopt35/linkareer/api/controller/OfficialController.java
@@ -1,0 +1,54 @@
+package sopt35.linkareer.api.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import sopt35.linkareer.api.dto.response.ErrorCode;
+import sopt35.linkareer.api.dto.response.OfficialListResponse;
+import sopt35.linkareer.domain.official.application.dto.response.OfficialDto;
+import sopt35.linkareer.domain.official.application.service.OfficialService;
+import sopt35.linkareer.domain.official.infra.Official.Category;
+import sopt35.linkareer.global.exception.LinkareerException;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1")
+public class OfficialController {
+
+    private final OfficialService officialService;
+
+    public OfficialController(OfficialService officialService) {
+        this.officialService = officialService;
+    }
+
+    // 카테고리에 맞는 공고 리스트를 조회하는 API
+    @GetMapping("/officiallist")
+    ResponseEntity<OfficialListResponse> getOfficialList(
+            @Validated @RequestHeader Long memberId,
+            @Validated @RequestParam(value = "category") String category
+    ) {
+        List<OfficialDto> officialList = officialService.getOfficialListByCategory(
+                memberId,
+                validateCreateCategory(category)
+        );
+        return ResponseEntity.ok(OfficialListResponse.from(officialList));
+    }
+
+    // 카테고리 유효성 검사 메서드
+    private Category validateCreateCategory(String category) {
+        if (category == null || category.isEmpty()) {
+            throw new LinkareerException(ErrorCode.INVALID_INPUT_CATEGORY_VALUE);
+        }
+        return validateCategory(category);
+    }
+
+    // 카테고리 값을 검증하고 변환하는 메서드
+    private Category validateCategory(String category) {
+        try {
+            return Category.valueOf(category.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new LinkareerException(ErrorCode.CATEGORY_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/sopt35/linkareer/api/controller/OfficialController.java
+++ b/src/main/java/sopt35/linkareer/api/controller/OfficialController.java
@@ -7,7 +7,7 @@ import sopt35.linkareer.api.dto.response.ErrorCode;
 import sopt35.linkareer.api.dto.response.OfficialListResponse;
 import sopt35.linkareer.domain.official.application.dto.response.OfficialDto;
 import sopt35.linkareer.domain.official.application.service.OfficialService;
-import sopt35.linkareer.domain.official.infra.Official.Category;
+import sopt35.linkareer.domain.official.infra.Category;
 import sopt35.linkareer.global.exception.LinkareerException;
 
 import java.util.List;

--- a/src/main/java/sopt35/linkareer/api/dto/response/ErrorCode.java
+++ b/src/main/java/sopt35/linkareer/api/dto/response/ErrorCode.java
@@ -1,0 +1,17 @@
+package sopt35.linkareer.api.dto.response;
+
+public enum ErrorCode {
+    INVALID_INPUT_VALUE("유효하지 않은 요청입니다."),
+    INVALID_INPUT_CATEGORY_VALUE("카테고리는 필수 항목입니다."),
+    INVALID_INPUT_OFFICIAL_VALUE("잘못된 공고 리스트 요청입니다."),
+    CATEGORY_NOT_FOUND("존재하지 않는 카테고리입니다."),
+    INTERNAL_SERVER_ERROR("서버 내부 오류입니다.");
+
+    private final String message;
+
+    ErrorCode(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() { return message; }
+}

--- a/src/main/java/sopt35/linkareer/api/dto/response/ErrorResponse.java
+++ b/src/main/java/sopt35/linkareer/api/dto/response/ErrorResponse.java
@@ -1,0 +1,22 @@
+package sopt35.linkareer.api.dto.response;
+
+/*
+에러 응답을 정의한 클래스
+ */
+public class ErrorResponse {
+    private final String message;
+
+    // 기본 메시지 생성
+    public ErrorResponse(ErrorCode errorCode) {
+        this.message = errorCode.getMessage();
+    }
+
+    // 커스텀 메시지 생성
+    public ErrorResponse(ErrorCode errorCode, String customMessage) {
+        this.message = customMessage != null ? customMessage : errorCode.getMessage();
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/sopt35/linkareer/api/dto/response/OfficialListResponse.java
+++ b/src/main/java/sopt35/linkareer/api/dto/response/OfficialListResponse.java
@@ -1,0 +1,23 @@
+package sopt35.linkareer.api.dto.response;
+
+import sopt35.linkareer.domain.official.application.dto.response.OfficialDto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/*
+List<Official>를 받아 List<OfficialResponse>로 변환
+ */
+public record OfficialListResponse(List<OfficialResponse> officialList) {
+
+    // official 리스트를 받아 OfficialResponse 리스트로 변환
+    public static OfficialListResponse from(List<OfficialDto> officialList) {
+        List<OfficialResponse> OfficialResponse = officialList.stream()
+                .map(official -> new OfficialResponse(
+                        official.getId(), official.getInterestJob(), official.getImageUrl(),
+                        official.getTitle(), official.getCompanyName(), official.getTag(),
+                        official.getViews(), official.getComments(), official.getDDay(), official.isBookmark()))
+                .collect(Collectors.toList());
+        return new OfficialListResponse(OfficialResponse);
+    }
+}

--- a/src/main/java/sopt35/linkareer/api/dto/response/OfficialListResponse.java
+++ b/src/main/java/sopt35/linkareer/api/dto/response/OfficialListResponse.java
@@ -3,7 +3,6 @@ package sopt35.linkareer.api.dto.response;
 import sopt35.linkareer.domain.official.application.dto.response.OfficialDto;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /*
 List<Official>를 받아 List<OfficialResponse>로 변환
@@ -12,12 +11,9 @@ public record OfficialListResponse(List<OfficialResponse> officialList) {
 
     // official 리스트를 받아 OfficialResponse 리스트로 변환
     public static OfficialListResponse from(List<OfficialDto> officialList) {
-        List<OfficialResponse> OfficialResponse = officialList.stream()
-                .map(official -> new OfficialResponse(
-                        official.getId(), official.getInterestJob(), official.getImageUrl(),
-                        official.getTitle(), official.getCompanyName(), official.getTag(),
-                        official.getViews(), official.getComments(), official.getDDay(), official.isBookmark()))
-                .collect(Collectors.toList());
-        return new OfficialListResponse(OfficialResponse);
+        List<OfficialResponse> officialResponses = officialList.stream()
+                .map(OfficialResponse::from)
+                .toList();
+        return new OfficialListResponse(officialResponses);
     }
 }

--- a/src/main/java/sopt35/linkareer/api/dto/response/OfficialResponse.java
+++ b/src/main/java/sopt35/linkareer/api/dto/response/OfficialResponse.java
@@ -1,0 +1,42 @@
+package sopt35.linkareer.api.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OfficialResponse {
+    private final long id;
+    private String interestJob;
+    private String imageUrl;
+    private String title;
+    private String companyName;
+    private String tag;
+    private Integer views;
+    private Integer comments;
+    private String dDay;
+    private boolean bookmark;
+
+    public OfficialResponse(Long id, String interestJob, String imageUrl, String title, String companyName, String tag, Integer views, Integer comments, String dDay, boolean bookmark) {
+        this.id = id;
+        this.interestJob = interestJob;
+        this.imageUrl = imageUrl;
+        this.title = title;
+        this.companyName = companyName;
+        this.tag = tag;
+        this.views = views;
+        this.comments = comments;
+        this.dDay = dDay;
+        this.bookmark = bookmark;
+    }
+
+    // Getters
+    public Long getId() { return id; }
+    public String getInterestJob() { return interestJob; }
+    public String getImageUrl() { return imageUrl; }
+    public String getTitle() { return title; }
+    public String getCompanyName() { return companyName; }
+    public String getTag() { return tag; }
+    public Integer getViews() { return views; }
+    public Integer getComments() { return comments; }
+    public String getDDay() { return dDay; }
+    public boolean isBookmark() { return bookmark; }
+}

--- a/src/main/java/sopt35/linkareer/api/dto/response/OfficialResponse.java
+++ b/src/main/java/sopt35/linkareer/api/dto/response/OfficialResponse.java
@@ -1,6 +1,7 @@
 package sopt35.linkareer.api.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import sopt35.linkareer.domain.official.application.dto.response.OfficialDto;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class OfficialResponse {
@@ -26,6 +27,21 @@ public class OfficialResponse {
         this.comments = comments;
         this.dDay = dDay;
         this.bookmark = bookmark;
+    }
+
+    public static OfficialResponse from(OfficialDto officialDto) {
+        return new OfficialResponse(
+                officialDto.getId(),
+                officialDto.getInterestJob(),
+                officialDto.getImageUrl(),
+                officialDto.getTitle(),
+                officialDto.getCompanyName(),
+                officialDto.getTag(),
+                officialDto.getViews(),
+                officialDto.getComments(),
+                officialDto.getDDay(),
+                officialDto.isBookmark()
+        );
     }
 
     // Getters

--- a/src/main/java/sopt35/linkareer/domain/official/application/dto/response/OfficialDto.java
+++ b/src/main/java/sopt35/linkareer/domain/official/application/dto/response/OfficialDto.java
@@ -1,0 +1,40 @@
+package sopt35.linkareer.domain.official.application.dto.response;
+
+public class OfficialDto {
+    private Long id;
+    private final String interestJob;
+    private String imageUrl;
+    private String title;
+    private String companyName;
+    private String tag;
+    private Integer views;
+    private Integer comments;
+    private String dDay;
+    private boolean bookmark;
+
+    // Constructor
+    public OfficialDto(Long id, String interestJob, String imageUrl, String title, String companyName, String tag, Integer views, Integer comments, String dDay, boolean bookmark) {
+        this.id = id;
+        this.interestJob = interestJob;
+        this.imageUrl = imageUrl;
+        this.title = title;
+        this.companyName = companyName;
+        this.tag = tag;
+        this.views = views;
+        this.comments = comments;
+        this.dDay = dDay;
+        this.bookmark = bookmark;
+    }
+
+    // Getters
+    public Long getId() { return id; }
+    public String getInterestJob() { return interestJob; }
+    public String getImageUrl() { return imageUrl; }
+    public String getTitle() { return title; }
+    public String getCompanyName() { return companyName; }
+    public String getTag() { return tag; }
+    public Integer getViews() { return views; }
+    public Integer getComments() { return comments; }
+    public String getDDay() { return dDay; }
+    public boolean isBookmark() { return bookmark; }
+}

--- a/src/main/java/sopt35/linkareer/domain/official/application/dto/response/OfficialDto.java
+++ b/src/main/java/sopt35/linkareer/domain/official/application/dto/response/OfficialDto.java
@@ -1,5 +1,7 @@
 package sopt35.linkareer.domain.official.application.dto.response;
 
+import sopt35.linkareer.domain.official.infra.Official;
+
 public class OfficialDto {
     private Long id;
     private final String interestJob;
@@ -23,6 +25,21 @@ public class OfficialDto {
         this.comments = comments;
         this.dDay = dDay;
         this.bookmark = bookmark;
+    }
+
+    public static OfficialDto from(Official official, String dDay) {
+        return new OfficialDto(
+                official.getId(),
+                official.getInterestJob(),
+                official.getImageUrl(),
+                official.getTitle(),
+                official.getCompanyName(),
+                official.getTag(),
+                official.getViews(),
+                official.getComments(),
+                dDay,
+                official.isBookmark()
+        );
     }
 
     // Getters

--- a/src/main/java/sopt35/linkareer/domain/official/application/dto/response/OfficialDto.java
+++ b/src/main/java/sopt35/linkareer/domain/official/application/dto/response/OfficialDto.java
@@ -1,5 +1,8 @@
 package sopt35.linkareer.domain.official.application.dto.response;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
 public class OfficialDto {
     private Long id;
     private final String interestJob;
@@ -12,8 +15,7 @@ public class OfficialDto {
     private String dDay;
     private boolean bookmark;
 
-    // Constructor
-    public OfficialDto(Long id, String interestJob, String imageUrl, String title, String companyName, String tag, Integer views, Integer comments, String dDay, boolean bookmark) {
+    public OfficialDto(Long id, String interestJob, String imageUrl, String title, String companyName, String tag, Integer views, Integer comments, LocalDate dDay, boolean bookmark) {
         this.id = id;
         this.interestJob = interestJob;
         this.imageUrl = imageUrl;
@@ -22,7 +24,7 @@ public class OfficialDto {
         this.tag = tag;
         this.views = views;
         this.comments = comments;
-        this.dDay = dDay;
+        this.dDay = calculateDDay(dDay);
         this.bookmark = bookmark;
     }
 
@@ -37,4 +39,18 @@ public class OfficialDto {
     public Integer getComments() { return comments; }
     public String getDDay() { return dDay; }
     public boolean isBookmark() { return bookmark; }
+
+    // D-Day 계산 메서드
+    private String calculateDDay(LocalDate targetDate) {
+        LocalDate today = LocalDate.now(); // 오늘 날짜 기준
+        long daysBetween = ChronoUnit.DAYS.between(today, targetDate); // 날짜 차이 계산
+
+        if (daysBetween > 0) {
+            return "D-" + daysBetween; // 미래 날짜
+        } else if (daysBetween == 0) {
+            return "D-Day"; // 오늘
+        } else {
+            return "D+" + Math.abs(daysBetween); // 과거 날짜
+        }
+    }
 }

--- a/src/main/java/sopt35/linkareer/domain/official/application/dto/response/OfficialDto.java
+++ b/src/main/java/sopt35/linkareer/domain/official/application/dto/response/OfficialDto.java
@@ -1,8 +1,5 @@
 package sopt35.linkareer.domain.official.application.dto.response;
 
-import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
-
 public class OfficialDto {
     private Long id;
     private final String interestJob;
@@ -15,7 +12,7 @@ public class OfficialDto {
     private String dDay;
     private boolean bookmark;
 
-    public OfficialDto(Long id, String interestJob, String imageUrl, String title, String companyName, String tag, Integer views, Integer comments, LocalDate dDay, boolean bookmark) {
+    public OfficialDto(Long id, String interestJob, String imageUrl, String title, String companyName, String tag, Integer views, Integer comments, String dDay, boolean bookmark) {
         this.id = id;
         this.interestJob = interestJob;
         this.imageUrl = imageUrl;
@@ -24,7 +21,7 @@ public class OfficialDto {
         this.tag = tag;
         this.views = views;
         this.comments = comments;
-        this.dDay = calculateDDay(dDay);
+        this.dDay = dDay;
         this.bookmark = bookmark;
     }
 
@@ -39,18 +36,4 @@ public class OfficialDto {
     public Integer getComments() { return comments; }
     public String getDDay() { return dDay; }
     public boolean isBookmark() { return bookmark; }
-
-    // D-Day 계산 메서드
-    private String calculateDDay(LocalDate targetDate) {
-        LocalDate today = LocalDate.now(); // 오늘 날짜 기준
-        long daysBetween = ChronoUnit.DAYS.between(today, targetDate); // 날짜 차이 계산
-
-        if (daysBetween > 0) {
-            return "D-" + daysBetween; // 미래 날짜
-        } else if (daysBetween == 0) {
-            return "D-Day"; // 오늘
-        } else {
-            return "D+" + Math.abs(daysBetween); // 과거 날짜
-        }
-    }
 }

--- a/src/main/java/sopt35/linkareer/domain/official/application/service/OfficialService.java
+++ b/src/main/java/sopt35/linkareer/domain/official/application/service/OfficialService.java
@@ -1,0 +1,50 @@
+package sopt35.linkareer.domain.official.application.service;
+
+import org.springframework.stereotype.Service;
+import sopt35.linkareer.domain.official.application.dto.response.OfficialDto;
+import sopt35.linkareer.domain.official.infra.Official;
+import sopt35.linkareer.domain.official.infra.Official.Category;
+import sopt35.linkareer.domain.official.infra.repository.OfficialRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class OfficialService {
+    private final OfficialRepository officialRepository;
+
+    public OfficialService(OfficialRepository officialRepository) {
+        this.officialRepository = officialRepository;
+    }
+
+    // 추천 공고, 실시간 인기 공고 리스트 조회 API
+    public List<OfficialDto> getOfficialListByCategory(Long memberId, Category category) {
+        // Repository에서 엔티티 조회
+        List<Official> officialList;
+
+        // 추천 공고라면 (유저에게 '정규직 전환' 태그만 있다고 가정하고 해당 태그와 관련된 리스트 반환)
+        if(category == Category.RECOMMEND){
+            officialList = officialRepository.findAllByTag("정규직 전환");
+        }
+        // 실시간 인기 공고라면 (유저는 UX/UI 직무에 관심있다고 가정하고 해당 직무와 관련된 리스트 반환)
+        else {
+            officialList = officialRepository.findAllByInterestJob("UX/UI");
+        }
+        // 엔티티 -> 도메인 모델로 변환
+        return officialList.stream()
+                .map(official -> new OfficialDto(
+                        official.getId(),
+                        official.getInterestJob(),
+                        official.getImageUrl(),
+                        official.getTitle(),
+                        official.getCompanyName(),
+                        official.getTag(),
+                        official.getViews(),
+                        official.getComments(),
+                        official.getDDay(),
+                        official.isBookmark()
+                ))
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/sopt35/linkareer/domain/official/application/service/OfficialService.java
+++ b/src/main/java/sopt35/linkareer/domain/official/application/service/OfficialService.java
@@ -2,14 +2,13 @@ package sopt35.linkareer.domain.official.application.service;
 
 import org.springframework.stereotype.Service;
 import sopt35.linkareer.domain.official.application.dto.response.OfficialDto;
+import sopt35.linkareer.domain.official.infra.Category;
 import sopt35.linkareer.domain.official.infra.Official;
-import sopt35.linkareer.domain.official.infra.Official.Category;
 import sopt35.linkareer.domain.official.infra.repository.OfficialRepository;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class OfficialService {
@@ -36,22 +35,12 @@ public class OfficialService {
         else {
             officialList = officialRepository.findAllByInterestJob("UX/UI");
         }
+
         // 엔티티 -> 도메인 모델로 변환
         return officialList.stream()
                 .filter(official -> !isPastDDay(official.getDDay()))
-                .map(official -> new OfficialDto(
-                        official.getId(),
-                        official.getInterestJob(),
-                        official.getImageUrl(),
-                        official.getTitle(),
-                        official.getCompanyName(),
-                        official.getTag(),
-                        official.getViews(),
-                        official.getComments(),
-                        calculateDDay(official.getDDay()),
-                        official.isBookmark()
-                ))
-                .collect(Collectors.toList());
+                .map(official -> OfficialDto.from(official, calculateDDay(official.getDDay())))
+                .toList();
     }
 
     // 날짜가 지난 공고인지 확인

--- a/src/main/java/sopt35/linkareer/domain/official/application/service/OfficialService.java
+++ b/src/main/java/sopt35/linkareer/domain/official/application/service/OfficialService.java
@@ -6,6 +6,8 @@ import sopt35.linkareer.domain.official.infra.Official;
 import sopt35.linkareer.domain.official.infra.Official.Category;
 import sopt35.linkareer.domain.official.infra.repository.OfficialRepository;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -41,10 +43,24 @@ public class OfficialService {
                         official.getTag(),
                         official.getViews(),
                         official.getComments(),
-                        official.getDDay(),
+                        calculateDDay(official.getDDay()),
                         official.isBookmark()
                 ))
                 .collect(Collectors.toList());
+    }
+
+    // D-Day 계산 메서드
+    private String calculateDDay(LocalDate targetDate) {
+        LocalDate today = LocalDate.now(); // 오늘 날짜 기준
+        long daysBetween = ChronoUnit.DAYS.between(today, targetDate); // 날짜 차이 계산
+
+        if (daysBetween > 0) {
+            return "D-" + daysBetween; // 미래 날짜
+        } else if (daysBetween == 0) {
+            return "D-Day"; // 오늘
+        } else {
+            return "D+" + Math.abs(daysBetween); // 과거 날짜
+        }
     }
 
 }

--- a/src/main/java/sopt35/linkareer/domain/official/application/service/OfficialService.java
+++ b/src/main/java/sopt35/linkareer/domain/official/application/service/OfficialService.java
@@ -15,6 +15,10 @@ import java.util.stream.Collectors;
 public class OfficialService {
     private final OfficialRepository officialRepository;
 
+    private static final String FUTURE_PREFIX = "D-";
+    private static final String TODAY = "D-Day";
+    private static final String PAST = null;
+
     public OfficialService(OfficialRepository officialRepository) {
         this.officialRepository = officialRepository;
     }
@@ -34,6 +38,7 @@ public class OfficialService {
         }
         // 엔티티 -> 도메인 모델로 변환
         return officialList.stream()
+                .filter(official -> !isPastDDay(official.getDDay()))
                 .map(official -> new OfficialDto(
                         official.getId(),
                         official.getInterestJob(),
@@ -49,17 +54,22 @@ public class OfficialService {
                 .collect(Collectors.toList());
     }
 
+    // 날짜가 지난 공고인지 확인
+    private boolean isPastDDay(LocalDate targetDate) {
+        return LocalDate.now().isAfter(targetDate); // 오늘 이후인지 체크
+    }
+
     // D-Day 계산 메서드
     private String calculateDDay(LocalDate targetDate) {
         LocalDate today = LocalDate.now(); // 오늘 날짜 기준
         long daysBetween = ChronoUnit.DAYS.between(today, targetDate); // 날짜 차이 계산
 
         if (daysBetween > 0) {
-            return "D-" + daysBetween; // 미래 날짜
+            return FUTURE_PREFIX + daysBetween; // 미래 날짜
         } else if (daysBetween == 0) {
-            return "D-Day"; // 오늘
+            return TODAY; // 오늘
         } else {
-            return "D+" + Math.abs(daysBetween); // 과거 날짜
+            return PAST; // 지난 날짜
         }
     }
 

--- a/src/main/java/sopt35/linkareer/domain/official/infra/Category.java
+++ b/src/main/java/sopt35/linkareer/domain/official/infra/Category.java
@@ -1,0 +1,6 @@
+package sopt35.linkareer.domain.official.infra;
+
+public enum Category {
+    RECOMMEND, // 추천 공고
+    POPULAR // 실시간 인기 공고
+}

--- a/src/main/java/sopt35/linkareer/domain/official/infra/Official.java
+++ b/src/main/java/sopt35/linkareer/domain/official/infra/Official.java
@@ -44,6 +44,22 @@ public class Official {
     @Column(nullable = false)
     private boolean bookmark;
 
+    protected Official() {}
+
+    public Official(final Long id, final String interestJob, final String imageUrl, final String title, final String companyName,
+                    final String tag, final int views, final int comments, final LocalDate dDay, final boolean bookmark) {
+        this.id = id;
+        this.interestJob = interestJob;
+        this.imageUrl = imageUrl;
+        this.title = title;
+        this.companyName = companyName;
+        this.tag = tag;
+        this.views = views;
+        this.comments = comments;
+        this.dDay = dDay;
+        this.bookmark = bookmark;
+    }
+
     // Getters
     public Long getId() { return id; }
     public String getInterestJob() { return interestJob; }

--- a/src/main/java/sopt35/linkareer/domain/official/infra/Official.java
+++ b/src/main/java/sopt35/linkareer/domain/official/infra/Official.java
@@ -1,6 +1,7 @@
 package sopt35.linkareer.domain.official.infra;
 
 import jakarta.persistence.*;
+import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
@@ -26,10 +27,10 @@ public class Official {
     @Column(nullable = false)
     private String tag;
 
-    @Column(nullable = false)
+    @ColumnDefault("0")
     private Integer views;
 
-    @Column(nullable = false)
+    @ColumnDefault("0")
     private Integer comments;
 
     @Column(nullable = false)
@@ -49,4 +50,11 @@ public class Official {
     public Integer getComments() { return comments; }
     public String getDDay() { return dDay; }
     public boolean isBookmark() { return bookmark; }
+
+    // 카테고리 Enum
+    public enum Category {
+        RECOMMEND, // 추천 공고
+        POPULAR // 실시간 인기 공고
+    }
+
 }

--- a/src/main/java/sopt35/linkareer/domain/official/infra/Official.java
+++ b/src/main/java/sopt35/linkareer/domain/official/infra/Official.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDate;
+
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 public class Official {
@@ -28,16 +30,19 @@ public class Official {
     private String tag;
 
     @ColumnDefault("0")
-    private Integer views;
+    @Column(nullable = false)
+    private int views;
 
     @ColumnDefault("0")
-    private Integer comments;
+    @Column(nullable = false)
+    private int comments;
 
     @Column(nullable = false)
-    private String dDay;
+    private LocalDate dDay;
 
+    @ColumnDefault("false")
     @Column(nullable = false)
-    private boolean bookmark = false;
+    private boolean bookmark;
 
     // Getters
     public Long getId() { return id; }
@@ -46,9 +51,9 @@ public class Official {
     public String getTitle() { return title; }
     public String getCompanyName() { return companyName; }
     public String getTag() { return tag; }
-    public Integer getViews() { return views; }
-    public Integer getComments() { return comments; }
-    public String getDDay() { return dDay; }
+    public int getViews() { return views; }
+    public int getComments() { return comments; }
+    public LocalDate getDDay() { return dDay; }
     public boolean isBookmark() { return bookmark; }
 
     // 카테고리 Enum

--- a/src/main/java/sopt35/linkareer/domain/official/infra/Official.java
+++ b/src/main/java/sopt35/linkareer/domain/official/infra/Official.java
@@ -72,10 +72,4 @@ public class Official {
     public LocalDate getDDay() { return dDay; }
     public boolean isBookmark() { return bookmark; }
 
-    // 카테고리 Enum
-    public enum Category {
-        RECOMMEND, // 추천 공고
-        POPULAR // 실시간 인기 공고
-    }
-
 }

--- a/src/main/java/sopt35/linkareer/domain/official/infra/repository/OfficialRepository.java
+++ b/src/main/java/sopt35/linkareer/domain/official/infra/repository/OfficialRepository.java
@@ -1,0 +1,12 @@
+package sopt35.linkareer.domain.official.infra.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sopt35.linkareer.domain.official.infra.Official;
+import sopt35.linkareer.domain.official.infra.Official.*;
+
+import java.util.List;
+
+public interface OfficialRepository extends JpaRepository<Official, Long> {
+    List<Official> findAllByInterestJob(String interestJob);
+    List<Official> findAllByTag(String tag);
+}

--- a/src/main/java/sopt35/linkareer/domain/official/validator/CategoryValidator.java
+++ b/src/main/java/sopt35/linkareer/domain/official/validator/CategoryValidator.java
@@ -1,0 +1,27 @@
+package sopt35.linkareer.domain.official.validator;
+
+import org.springframework.stereotype.Component;
+import sopt35.linkareer.api.dto.response.ErrorCode;
+import sopt35.linkareer.domain.official.infra.Category;
+import sopt35.linkareer.global.exception.LinkareerException;
+
+@Component
+public class CategoryValidator {
+
+    // 카테고리 값을 검증하고 변환
+    public Category validate(String category) {
+        if (category == null || category.isEmpty()) {
+            throw new LinkareerException(ErrorCode.INVALID_INPUT_CATEGORY_VALUE);
+        }
+        return toCategory(category);
+    }
+
+    // 카테고리 값을 Enum으로 변환
+    private Category toCategory(String category) {
+        try {
+            return Category.valueOf(category.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new LinkareerException(ErrorCode.CATEGORY_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/sopt35/linkareer/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sopt35/linkareer/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,41 @@
+package sopt35.linkareer.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import sopt35.linkareer.api.dto.response.ErrorCode;
+import sopt35.linkareer.api.dto.response.ErrorResponse;
+
+;
+
+/*
+전역에서 발생하는 예외를 처리하는 클래스
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // LinkareerException 처리
+    @ExceptionHandler(LinkareerException.class)
+    public ResponseEntity<ErrorResponse> handleLinkareerException(LinkareerException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
+
+    // @RequestBody 바인딩 에러 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse(ErrorCode.INVALID_INPUT_VALUE, message));
+    }
+
+    // 기타 예외 처리 (상태 코드 500)
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGenericException(Exception e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}
+

--- a/src/main/java/sopt35/linkareer/global/exception/LinkareerException.java
+++ b/src/main/java/sopt35/linkareer/global/exception/LinkareerException.java
@@ -1,0 +1,17 @@
+package sopt35.linkareer.global.exception;
+
+import sopt35.linkareer.api.dto.response.ErrorCode;
+
+public class LinkareerException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    // ErrorCode의 기본 메시지를 사용하는 생성자
+    public LinkareerException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #13 

### 🎋 작업중인 브랜치
- feat#13

### 💡 작업내용
- 추천 공고, 실시간 인기 공고 API 구현

### 🔑 주요 변경사항
- Official 엔티티에서는 날짜를 저장하고, DTO에서 디데이를 계산하여 포맷팅하는 형식으로 바꿨습니다.
- 전체적인 에러처리를 진행했습니다.
- 조회시 파라미터에 보내는 카테고리에 따라 추천 공고와 실시간 인기공고를 구분하였습니다!

### 🏞 스크린샷
<img width="300" alt="image" src="https://github.com/user-attachments/assets/d05143b8-8829-4200-9fa4-3f0457909e1c">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/8abc740f-0e0d-494d-87d6-bf6acddd2a9e">


closed #13 
